### PR TITLE
Update competitors and add Latvian location

### DIFF
--- a/src/data/competitors.json
+++ b/src/data/competitors.json
@@ -992,3 +992,59 @@
         "average": 999
     },
     {
+        "name": "Stoil Kalev",
+        "personId": "2013KALE01",
+        "country": "Bulgaria",
+        "comments": "Bulgaria - Sofia",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Teodor Nicolae Procopiu",
+        "personId": "",
+        "country": "Romania",
+        "comments": "Romania - Bucharest",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Tihomir Dulev",
+        "personId": "2015DULE03",
+        "country": "Bulgaria",
+        "comments": "Bulgaria - Sofia",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Valerio Colapinto",
+        "personId": "2019COLA01",
+        "country": "Italy",
+        "comments": "Italy - Monterotondo",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Valerio Raimondi Vallesi",
+        "personId": "2019VALL10",
+        "country": "Italy",
+        "comments": "Italy - Monterotondo",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Vlad Laz\u0103r",
+        "personId": "",
+        "country": "Romania",
+        "comments": "Romania - Bucharest",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Vladislav Sergunov",
+        "personId": "2019SERG03",
+        "country": "Russia",
+        "comments": "Russia - Moscow",
+        "single": 999,
+        "average": 999
+    }
+]

--- a/src/data/competitors.json
+++ b/src/data/competitors.json
@@ -96,6 +96,14 @@
         "average": 28.0
     },
     {
+        "name": "Jakob Gunnarsson",
+        "personId": "2015GUNN01",
+        "country": "Sweden",
+        "comments": "Sweden - Gothenburg",
+        "single": 23,
+        "average": 28.0
+    },
+    {
         "name": "Sergey Lahno",
         "personId": "2015LAHN01",
         "country": "Russia",
@@ -174,6 +182,14 @@
         "comments": "Romania - Boto\u015fani",
         "single": 28,
         "average": 29.0
+    },
+    {
+        "name": "Alexey Zharikov",
+        "personId": "2015ZHAR01",
+        "country": "Russia",
+        "comments": "Russia - Moscow",
+        "single": 23,
+        "average": 29.33
     },
     {
         "name": "Cl\u00e9ment Cherblanc",
@@ -302,6 +318,14 @@
         "comments": "Denmark - Frederiksberg",
         "single": 29,
         "average": 32.0
+    },
+    {
+        "name": "Matic Omulec",
+        "personId": "2010OMUL02",
+        "country": "Slovenia",
+        "comments": "Slovenia - Maribor",
+        "single": 26,
+        "average": 32.33
     },
     {
         "name": "Ulrik Bredland",
@@ -656,6 +680,14 @@
         "average": 58.33
     },
     {
+        "name": "Kasper Pasanen",
+        "personId": "2018PASA02",
+        "country": "Finland",
+        "comments": "Finland - Helsinki",
+        "single": 44,
+        "average": 60.33
+    },
+    {
         "name": "Alaric Pouchain",
         "personId": "2019POUC01",
         "country": "France",
@@ -701,6 +733,14 @@
         "country": "Netherlands",
         "comments": "Netherlands - Zeewolde",
         "single": 34,
+        "average": 999
+    },
+    {
+        "name": "Giovanni Centili",
+        "personId": "2018CENT02",
+        "country": "Italy",
+        "comments": "Italy - Monterotondo",
+        "single": 36,
         "average": 999
     },
     {
@@ -768,6 +808,14 @@
         "average": 999
     },
     {
+        "name": "Nikolai Gomelchuk",
+        "personId": "2019GOME13",
+        "country": "Russia",
+        "comments": "Russia - Moscow",
+        "single": 49,
+        "average": 999
+    },
+    {
         "name": "Alexander Kolev",
         "personId": "2019KOLE06",
         "country": "Bulgaria",
@@ -780,6 +828,14 @@
         "personId": "",
         "country": "USA",
         "comments": "Germany - Karlsfeld",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Biant Shkololli",
+        "personId": "2019SHKO01",
+        "country": "Kosovo",
+        "comments": "North Macedonia - Skopje",
         "single": 999,
         "average": 999
     },
@@ -852,6 +908,14 @@
         "personId": "2019MERZ01",
         "country": "Russia",
         "comments": "Russia - Moscow",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Nikola Pulkovski",
+        "personId": "2018PULK01",
+        "country": "Macedonia",
+        "comments": "North Macedonia - Skopje",
         "single": 999,
         "average": 999
     },

--- a/src/data/competitors.json
+++ b/src/data/competitors.json
@@ -904,6 +904,14 @@
         "average": 999
     },
     {
+        "name": "Mateo Minoski",
+        "personId": "2019MINO01",
+        "country": "Macedonia",
+        "comments": "North Macedonia - Skopje",
+        "single": 999,
+        "average": 999
+    },
+    {
         "name": "Matvey Merzlikin",
         "personId": "2019MERZ01",
         "country": "Russia",

--- a/src/data/competitors.json
+++ b/src/data/competitors.json
@@ -536,6 +536,14 @@
         "average": 39.67
     },
     {
+        "name": "Sergey Chirin",
+        "personId": "2015CHIR01",
+        "country": "Russia",
+        "comments": "Russia - Moscow",
+        "single": 33,
+        "average": 39.67
+    },
+    {
         "name": "Modest Podzolkin",
         "personId": "2017PODZ01",
         "country": "Ukraine",
@@ -744,6 +752,14 @@
         "average": 999
     },
     {
+        "name": "Aleksandar Arsovski",
+        "personId": "2018ARSO01",
+        "country": "Macedonia",
+        "comments": "North Macedonia - Skopje",
+        "single": 38,
+        "average": 999
+    },
+    {
         "name": "Ivan Polukarov",
         "personId": "2017POLU02",
         "country": "Russia",
@@ -840,10 +856,34 @@
         "average": 999
     },
     {
+        "name": "Borjan Baboski",
+        "personId": "2018BABO01",
+        "country": "Macedonia",
+        "comments": "North Macedonia - Skopje",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Darijan Saravinov",
+        "personId": "2019SARA13",
+        "country": "Macedonia",
+        "comments": "North Macedonia - Skopje",
+        "single": 999,
+        "average": 999
+    },
+    {
         "name": "David Tanaskovi\u0107",
         "personId": "2019TANA01",
         "country": "Bosnia and Herzegovina",
         "comments": "Croatia - Osijek",
+        "single": 999,
+        "average": 999
+    },
+    {
+        "name": "Diana Kostadinova",
+        "personId": "2019KOST12",
+        "country": "Macedonia",
+        "comments": "North Macedonia - Skopje",
         "single": 999,
         "average": 999
     },
@@ -920,6 +960,14 @@
         "average": 999
     },
     {
+        "name": "Nikola Dimitrovski",
+        "personId": "2018DIMI11",
+        "country": "Macedonia",
+        "comments": "North Macedonia - Skopje",
+        "single": 999,
+        "average": 999
+    },
+    {
         "name": "Nikola Pulkovski",
         "personId": "2018PULK01",
         "country": "Macedonia",
@@ -944,51 +992,3 @@
         "average": 999
     },
     {
-        "name": "Stoil Kalev",
-        "personId": "2013KALE01",
-        "country": "Bulgaria",
-        "comments": "Bulgaria - Sofia",
-        "single": 999,
-        "average": 999
-    },
-    {
-        "name": "Teodor Nicolae Procopiu",
-        "personId": "",
-        "country": "Romania",
-        "comments": "Romania - Bucharest",
-        "single": 999,
-        "average": 999
-    },
-    {
-        "name": "Valerio Colapinto",
-        "personId": "2019COLA01",
-        "country": "Italy",
-        "comments": "Italy - Monterotondo",
-        "single": 999,
-        "average": 999
-    },
-    {
-        "name": "Valerio Raimondi Vallesi",
-        "personId": "2019VALL10",
-        "country": "Italy",
-        "comments": "Italy - Monterotondo",
-        "single": 999,
-        "average": 999
-    },
-    {
-        "name": "Vlad Laz\u0103r",
-        "personId": "",
-        "country": "Romania",
-        "comments": "Romania - Bucharest",
-        "single": 999,
-        "average": 999
-    },
-    {
-        "name": "Vladislav Sergunov",
-        "personId": "2019SERG03",
-        "country": "Russia",
-        "comments": "Russia - Moscow",
-        "single": 999,
-        "average": 999
-    }
-]

--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -144,6 +144,18 @@
     "fullname": "Italy - Milano"
   },
   {
+    "lat": "57.1519400",
+    "lng": "24.8647200",
+    "country": "Latvia",
+    "city": "Sigulda",
+    "address": "Private address",
+    "delegate": "Jānis Zirnis",
+    "fee": "2 EUR",
+    "info": "",
+    "timezone": "UTC+2",
+    "fullname": "Latvia - Sigulda"
+  },
+  {
     "lat": "52.3324104",
     "lng": "5.5314603",
     "country": "Netherlands",


### PR DESCRIPTION
Yet another location which is why I already send another PR. I'd prefer to update the competitors less often if there are no new locations (or important location updates).

Janis told me to use the general coordinates of Sigulda instead of his private address, so I slightly edited the coordinates compared to the submitted coordinates in the spreadsheet to mirror his request.